### PR TITLE
chore: remove gcloud version arg

### DIFF
--- a/Dockerfile.go-alpine
+++ b/Dockerfile.go-alpine
@@ -1,12 +1,11 @@
 ARG JX_VERSION=2.0.560
 ARG KUBCTL_VERSION=v1.15.0
 ARG HELM_VERSION=v2.14.1
-ARG GCLOUD_VERSION=252.0.0-alpine
 
 FROM jenkinsxio/jx:$JX_VERSION as jx
 FROM lachlanevenson/k8s-kubectl:$KUBCTL_VERSION as kubectl
 FROM lachlanevenson/k8s-helm:$HELM_VERSION as helm
-FROM google/cloud-sdk:$GCLOUD_VERSION as gcloud
+FROM google/cloud-sdk:252.0.0-alpine as gcloud
 FROM groovy:2.5.7-jdk8-alpine as groovy
 FROM golang:1.12.7-alpine3.10
 


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

Removing ARG's for gcloud, as it is not required and dependabot should now pick up version bumps.
Done separately to the helm and kubctl ones as I'm not sure dependabot will update with alpine specific version.