### PR TITLE
fix: Revert "chore(deps): bump golang from 1.12.9-alpine3.10 to 1.13.0-alpine3.10"

### DIFF
--- a/Dockerfile.go-alpine
+++ b/Dockerfile.go-alpine
@@ -5,7 +5,7 @@ FROM lachlanevenson/k8s-kubectl:v1.15.3 as kubectl
 FROM lachlanevenson/k8s-helm:v2.14.3 as helm
 FROM google/cloud-sdk:261.0.0-alpine as gcloud
 FROM groovy:2.5.7-jdk8-alpine as groovy
-FROM golang:1.13.0-alpine3.10 as base
+FROM golang:1.12.9-alpine3.10 as base
 
 ARG user=developer
 ARG group=wheel


### PR DESCRIPTION
Reverts jenkins-x/dev-env-base#282